### PR TITLE
Fix readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -2,7 +2,7 @@
 tags:
 ---
 
-# Component: `redshift`
+# Component: `redshift-serverless`
 
 This component is responsible for provisioning Redshift clusters.
 


### PR DESCRIPTION
## what
- Copy CHANGELOG.md to `src/CHANGELOG.md`
- Generate `src/README.md` from `README.yaml`

## why
- `atmos vendor` should get readme files
